### PR TITLE
Setting token when MFA succeeds

### DIFF
--- a/src/Auth/RespondsMFAChallenge.php
+++ b/src/Auth/RespondsMFAChallenge.php
@@ -39,7 +39,7 @@ trait RespondsMFAChallenge
 
 
     /**
-     * AwsCognito constructor.
+     * RespondsMFAChallenge constructor.
      *
      * @param AwsCognito $cognito
      */

--- a/src/Auth/RespondsMFAChallenge.php
+++ b/src/Auth/RespondsMFAChallenge.php
@@ -11,7 +11,10 @@
 
 namespace Ellaisys\Cognito\Auth;
 
+use App\Models\User;
 use Aws\Result as AWSResult;
+use Ellaisys\Cognito\AwsCognito;
+use Ellaisys\Cognito\AwsCognitoClaim;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
@@ -27,6 +30,27 @@ use Ellaisys\Cognito\Exceptions\AwsCognitoException;
 
 trait RespondsMFAChallenge
 {
+    /**
+     * The AwsCognito instance.
+     *
+     * @var \Ellaisys\Cognito\AwsCognito
+     */
+    protected $cognito;
+
+
+    /**
+     * AwsCognito constructor.
+     *
+     * @param AwsCognito $cognito
+     */
+    public function __construct(AwsCognito $cognito) {
+        $this->cognito = $cognito;
+    }
+
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws ValidationException
+     */
     public function respondMFAChallenge($request)
     {
         if ($request instanceof Request) {
@@ -48,6 +72,9 @@ trait RespondsMFAChallenge
         if (is_string($result)) {
             return $response = response()->json(['error' => 'cognito.'.$result], 400);
         } else if ($result instanceof AWSResult) {
+            $user = User::where('email', $request['email'])->first();
+            $claim = new AwsCognitoClaim($result, $user, 'email');
+            $this->cognito->setClaim($claim)->storeToken();
             return $result['AuthenticationResult'];
         }
 


### PR DESCRIPTION
In the [previous PR](https://github.com/ellaisys/aws-cognito/pull/9) after MFA succeeds, there no setting of the token for library cache.

This PR fixes that. 