### PR TITLE
AuthenticatesUsers->attemptLogin: possibility to change key fields us…

### DIFF
--- a/src/Auth/AuthenticatesUsers.php
+++ b/src/Auth/AuthenticatesUsers.php
@@ -43,15 +43,12 @@ trait AuthenticatesUsers
     protected function attemptLogin(Collection $request, string $guard='web', string $paramUsername='email', string $paramPassword='password', bool $isJsonResponse=false)
     {
         try {
-            //Get key fields
-            $keyUsername = 'email';
-            $keyPassword = 'password';
             $rememberMe = $request->has('remember')?$request['remember']:false;
 
             //Generate credentials array
             $credentials = [
-                $keyUsername => $request[$paramUsername], 
-                $keyPassword => $request[$paramPassword]
+                $paramUsername => $request[$paramUsername], 
+                $paramPassword => $request[$paramPassword]
             ];
 
             //Authenticate User


### PR DESCRIPTION
It looks like a user is not able to manage the credential names, because 'email' and 'password' keys are hardcoded. 
For example, I use 'username' instead of 'email' in my aws-cognito, so I thought maybe it's better to make the properties dynamic using the arguments of "attemptLogin" method.