### PR TITLE
aws cognito signin attribute is adjustable

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Add the following fields to your `.env` file and set the values according to you
     AWS_COGNITO_USER_POOL_ID="xxxxxxxxxxxxxxxxx"
     AWS_COGNITO_REGION="xxxxxxxxxxx" //optional - default value is 'us-east-1'
     AWS_COGNITO_VERSION="latest" //optional - default value is 'latest'
+    AWS_COGNITO_SIGNIN_ATTRIBUTE="email" //optional - default value is 'email', you can choose to have users sign in with an email address, phone number, username or preferred username
 
 ```
 For more details on how to find AWS_COGNITO_CLIENT_ID, AWS_COGNITO_CLIENT_SECRET and AWS_COGNITO_USER_POOL_ID for your application, please refer [COGNITOCONFIG File](COGNITOCONFIG.md)

--- a/config/config.php
+++ b/config/config.php
@@ -21,6 +21,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | AWS configurations
+    |--------------------------------------------------------------------------
+    |
+    | You can choose to have users sign in with an email address, phone number, username or preferred username
+    |
+    */
+    'signin_attribute' => env('AWS_COGNITO_SIGNIN_ATTRIBUTE', 'email'),
+
+    /*
+    |--------------------------------------------------------------------------
     | AWS Cognito configurations
     |--------------------------------------------------------------------------
     |

--- a/src/Auth/AuthenticatesUsers.php
+++ b/src/Auth/AuthenticatesUsers.php
@@ -43,15 +43,12 @@ trait AuthenticatesUsers
     protected function attemptLogin(Collection $request, string $guard='web', string $paramUsername='email', string $paramPassword='password', bool $isJsonResponse=false)
     {
         try {
-            //Get key fields
-            $keyUsername = 'email';
-            $keyPassword = 'password';
             $rememberMe = $request->has('remember')?$request['remember']:false;
 
             //Generate credentials array
             $credentials = [
-                $keyUsername => $request[$paramUsername], 
-                $keyPassword => $request[$paramPassword]
+                $paramUsername => $request[$paramUsername], 
+                $paramPassword => $request[$paramPassword]
             ];
 
             //Authenticate User

--- a/src/Guards/CognitoSessionGuard.php
+++ b/src/Guards/CognitoSessionGuard.php
@@ -34,6 +34,14 @@ use Aws\CognitoIdentityProvider\Exception\CognitoIdentityProviderException;
 
 class CognitoSessionGuard extends SessionGuard implements StatefulGuard
 {
+
+    /**
+     * Username key
+     * 
+     * @var  \string  
+     */
+    protected $keyUsername;
+
     /**
      * @var AwsCognitoClient
      */
@@ -61,9 +69,11 @@ class CognitoSessionGuard extends SessionGuard implements StatefulGuard
         AwsCognitoClient $client,
         UserProvider $provider,
         Session $session,
-        ?Request $request = null
+        ?Request $request = null,
+        string $keyUsername = 'email'
     ) {
         $this->client = $client;
+        $this->keyUsername = $keyUsername;
         parent::__construct($name, $provider, $session, $request);
     }
 
@@ -77,7 +87,7 @@ class CognitoSessionGuard extends SessionGuard implements StatefulGuard
     protected function hasValidCredentials($user, $credentials)
     {
         /** @var Result $response */
-        $result = $this->client->authenticate($credentials['email'], $credentials['password']);
+        $result = $this->client->authenticate($credentials[$this->keyUsername], $credentials['password']);
 
         if (!empty($result) && $result instanceof AwsResult) {
 

--- a/src/Providers/AwsCognitoServiceProvider.php
+++ b/src/Providers/AwsCognitoServiceProvider.php
@@ -176,7 +176,8 @@ class AwsCognitoServiceProvider extends ServiceProvider
                 $client = $app->make(AwsCognitoClient::class),
                 $app['auth']->createUserProvider($config['provider']),
                 $app['session.store'],
-                $app['request']
+                $app['request'],
+                config('cognito.signin_attribute')
             );
 
             $guard->setCookieJar($this->app['cookie']);
@@ -201,7 +202,8 @@ class AwsCognitoServiceProvider extends ServiceProvider
                 $app['ellaisys.aws.cognito'],
                 $client = $app->make(AwsCognitoClient::class),
                 $app['request'],
-                Auth::createUserProvider($config['provider'])
+                Auth::createUserProvider($config['provider']),
+                config('cognito.signin_attribute')
             );
 
             $guard->setRequest($app->refresh('request', $guard, 'setRequest'));


### PR DESCRIPTION
It looks like a user is not able to manage the credential names, because 'email' and 'password' keys are hardcoded.
For example, I use 'username' instead of 'email' in my aws-cognito, so I thought maybe it's better to make the properties adjustable