### PR TITLE
Fix error when ResetsPasswords expecting JSON

### DIFF
--- a/src/Auth/ResetsPasswords.php
+++ b/src/Auth/ResetsPasswords.php
@@ -12,6 +12,7 @@
 namespace Ellaisys\Cognito\Auth;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Password;


### PR DESCRIPTION
Without this PR, when we try to resets password expecting a json response, the follow error appears:
```
{
	"message": "Class \"Ellaisys\\Cognito\\Auth\\JsonResponse\" not found",
	"exception": "Error",
	"file": "/app/vendor/ellaisys/aws-cognito/src/Auth/ResetsPasswords.php",
	"line": 89,
        (...)
```

This PR fixes this error.