### PR TITLE
Get cognito client

### DIFF
--- a/src/AwsCognitoClient.php
+++ b/src/AwsCognitoClient.php
@@ -170,6 +170,13 @@ class AwsCognitoClient
         $this->boolClientSecret = $boolClientSecret;
     }
 
+    /**
+     * @return CognitoIdentityProviderClient
+     */
+    public function getCognitoIdentityProviderClient()
+    {
+        return $this->client;
+    }
 
     /**
      * Checks if credentials of a user are valid.


### PR DESCRIPTION
Hi, sometimes I need to use some cognito functions (adminSetUserPassword ...) which are not implemented yet in this package.

So I want to call those functions like this:

```php
app(AwsCognitoClient::class)->getCognitoIdentityProviderClient()->adminSetUserPassword($params);
```

This PR will add `getCognitoIdentityProviderClient` to `AwsCognitoClient` class