### PR TITLE
fix:  Fetch keyUsername from config in AwsCognitoServiceProvider

### DIFF
--- a/src/Providers/AwsCognitoServiceProvider.php
+++ b/src/Providers/AwsCognitoServiceProvider.php
@@ -250,7 +250,7 @@ class AwsCognitoServiceProvider extends ServiceProvider
                 $client = $app->make(AwsCognitoClient::class),
                 $app['request'],
                 Auth::createUserProvider($config['provider']),
-                config('cognito_user_fields.email', 'email')
+                config('cognito.cognito_user_fields.email', 'email')
             );
 
             $guard->setRequest($app->refresh('request', $guard, 'setRequest'));


### PR DESCRIPTION
When cognito_user_fields.email is set to a different value, the setting is not applied and the default value is used.

String to load configuration is missing 'cognito' prefix in AwsCognitoServiceProvider.

This PR fixes this issue by adding the prefix to the config string.