### PR TITLE
issue 82: fixed for first login failure after auto changing password

### DIFF
--- a/src/Guards/CognitoTokenGuard.php
+++ b/src/Guards/CognitoTokenGuard.php
@@ -142,6 +142,10 @@ class CognitoTokenGuard extends TokenGuard
 
                                     //Get the result object again
                                     $result = $this->client->authenticate($credentials[$this->keyUsername], $credentials['password']);
+
+                                    //Create claim token
+                                    $this->claim = new AwsCognitoClaim($result, $user, $credentials[$this->keyUsername]);
+
                                     if (empty($result)) {
                                         return false;
                                     } //End if


### PR DESCRIPTION
when you set the flags:
`AWS_COGNITO_FORCE_PASSWORD_CHANGE_API=false`
`AWS_COGNITO_FORCE_PASSWORD_AUTO_UPDATE_API=true`
to auto confirm user password login always fails on the first attempt.

Added `AwsCognitoClaim()` call after `confirmPassword()` and `authenticate()` calls.