### PR TITLE
3ev/feature/734 cognito ammends

### DIFF
--- a/config/cognito.php
+++ b/config/cognito.php
@@ -32,6 +32,8 @@ return [
     'app_client_id'     => env('AWS_COGNITO_CLIENT_ID'),
     'app_client_secret' => env('AWS_COGNITO_CLIENT_SECRET'),
     'user_pool_id'      => env('AWS_COGNITO_USER_POOL_ID'),
+    'scheme'            => env('AWS_COGNITO_SCHEME', 'https'),
+    'endpoint'          => env('AWS_COGNITO_ENDPOINT'),
     'region'            => env('AWS_COGNITO_REGION', 'us-east-1'),
     'version'           => env('AWS_COGNITO_VERSION', 'latest'),
 

--- a/src/Providers/AwsCognitoServiceProvider.php
+++ b/src/Providers/AwsCognitoServiceProvider.php
@@ -38,7 +38,7 @@ use Aws\CognitoIdentityProvider\CognitoIdentityProviderClient;
  */
 class AwsCognitoServiceProvider extends ServiceProvider
 {
-    
+
     /**
      * Register the application services.
      *
@@ -87,11 +87,11 @@ class AwsCognitoServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             //Publish config
             $this->publishes([
-                __DIR__.'/../../config/cognito.php' => $this->app->configPath('cognito.php'),
+                __DIR__ . '/../../config/cognito.php' => $this->app->configPath('cognito.php'),
             ], 'cognito-config');
 
             $this->publishes([
-                __DIR__.'/../../database/migrations' => $this->app->databasePath('migrations'),
+                __DIR__ . '/../../database/migrations' => $this->app->databasePath('migrations'),
             ], 'cognito-migrations');
 
             // $this->publishes([
@@ -111,7 +111,7 @@ class AwsCognitoServiceProvider extends ServiceProvider
         $this->app->alias('ellaisys.aws.cognito', AwsCognito::class);
     }
 
-    
+
     /**
      * Setup the configuration for Cognito.
      *
@@ -120,7 +120,8 @@ class AwsCognitoServiceProvider extends ServiceProvider
     protected function configure()
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../../config/cognito.php', 'cognito'
+            __DIR__ . '/../../config/cognito.php',
+            'cognito'
         );
     } //Function ends
 
@@ -191,13 +192,15 @@ class AwsCognitoServiceProvider extends ServiceProvider
     {
         $this->app->singleton(AwsCognitoClient::class, function () {
             $aws_config = [
-                'region'      => config('cognito.region'),
-                'version'     => config('cognito.version')
+                'region' => config('cognito.region'),
+                'version' => config('cognito.version'),
+                'endpoint' => config('cognito.endpoint'),
+                'scheme' => config('cognito.scheme')
             ];
 
             //Set AWS Credentials
             $credentials = config('cognito.credentials');
-            if (! empty($credentials['key']) && ! empty($credentials['secret'])) {
+            if (!empty($credentials['key']) && !empty($credentials['secret'])) {
                 $aws_config['credentials'] = Arr::only($credentials, ['key', 'secret', 'token']);
             } //End if
 
@@ -274,7 +277,7 @@ class AwsCognitoServiceProvider extends ServiceProvider
      */
     protected function registerResources()
     {
-        $this->loadViewsFrom(__DIR__.'/../../resources/views', 'cognito');
+        $this->loadViewsFrom(__DIR__ . '/../../resources/views', 'cognito');
     } //Function ends
 
 
@@ -286,8 +289,8 @@ class AwsCognitoServiceProvider extends ServiceProvider
     protected function registerMigrations()
     {
         if (AwsCognito::$runsMigrations && $this->app->runningInConsole()) {
-            $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
+            $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
         } //End if
     } //Function ends
-    
+
 } //Class ends


### PR DESCRIPTION
## Requested Change 1 -  Two new config vars: cognito.endpoint & cognito.scheme
This PR wishes to add two new config variables called:
  'endpoint' => config('cognito.endpoint'),
  'scheme' => config('cognito.scheme')
  
The reason for this requested change is that we wish to unit test without having to use a live AWS cognito pool, instead we are able to use a local docker container that mocks AWS cognito pool however it'll require changing the endpoint.
  
This change does not break backwards compatability.

## Requested Change 2 - Refactor of refreshToken 
It seems that the refreshToken trait relies on fetching the user via a access token being set in the Auth header or session, however an accessToken can be expired but a refreshToken still valid.

Instead this refactor allows the passing in of a $user model to fetch the sub Id, it will default back to the original way if not set.

In addition the refreshToken wasn't being invalidated after being used, the token is now invalidated.
