### PR TITLE
Fix PHP 8.4 implicit nullable parameter deprecations

### DIFF
--- a/src/Auth/RegistersUsers.php
+++ b/src/Auth/RegistersUsers.php
@@ -53,7 +53,7 @@ trait RegistersUsers
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
-    public function invite(Request $request, array $clientMetadata=null)
+    public function invite(Request $request, ?array $clientMetadata = null)
     {
         $this->registrationType = 'invite';
         return $this->register($request, $clientMetadata, true);
@@ -66,8 +66,8 @@ trait RegistersUsers
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
-    public function register(Request $request, array $clientMetadata=null,
-        bool $ignoreConfigRegistrationType=false)
+    public function register(Request $request, ?array $clientMetadata = null,
+        bool $ignoreConfigRegistrationType = false)
     {
         $cognitoRegistered=false;
         $user = [];
@@ -153,7 +153,7 @@ trait RegistersUsers
      * @return \Illuminate\Http\Response
      * @throws InvalidUserFieldException
      */
-    public function createCognitoUser(Collection $request, array $clientMetadata=null, string $groupname=null)
+    public function createCognitoUser(Collection $request, ?array $clientMetadata = null, ?string $groupname = null)
     {
         //Initialize Cognito Attribute array
         $attributes = [];

--- a/src/Auth/SendsPasswordResetEmails.php
+++ b/src/Auth/SendsPasswordResetEmails.php
@@ -35,7 +35,7 @@ trait SendsPasswordResetEmails
      * 
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function sendResetLinkEmail(\Illuminate\Http\Request $request, string $usernameKey='email', bool $resetTypeCode=true, bool $isJsonResponse=false, array $attributes=null)
+    public function sendResetLinkEmail(\Illuminate\Http\Request $request, string $usernameKey = 'email', bool $resetTypeCode = true, bool $isJsonResponse = false, ?array $attributes = null)
     {
         try {        
             //Cognito reset link
@@ -75,7 +75,7 @@ trait SendsPasswordResetEmails
      * @param  \string  $username
      * @return \bool
      */
-    public function sendCognitoResetLinkEmail(string $username, array $clientMetadata=null)
+    public function sendCognitoResetLinkEmail(string $username, ?array $clientMetadata = null)
     {
         $response = null; $returnValue = false;
 

--- a/src/AwsCognitoClient.php
+++ b/src/AwsCognitoClient.php
@@ -247,7 +247,7 @@ class AwsCognitoClient
      * @return bool
      */
     public function register($username, $password, array $attributes = [],
-        array $clientMetadata=null, string $groupname=null)
+        ?array $clientMetadata = null, ?string $groupname = null)
     {
         try {
             //Build payload
@@ -291,7 +291,7 @@ class AwsCognitoClient
      * @param array $clientMetadata (optional)
      * @return string
      */
-    public function sendResetLink($username, array $clientMetadata=null)
+    public function sendResetLink($username, ?array $clientMetadata = null)
     {
         try {
             //Build payload
@@ -431,9 +431,9 @@ class AwsCognitoClient
      * @param string $messageAction (optional)
      * @return bool $groupname (optional)
      */
-    public function inviteUser(string $username, string $password=null, array $attributes = [],
-        array $clientMetadata=null, string $messageAction=null,
-        string $groupname=null)
+    public function inviteUser(string $username, ?string $password = null, array $attributes = [],
+        ?array $clientMetadata = null, ?string $messageAction = null,
+        ?string $groupname = null)
     {
         //Validate phone for MFA
         if (config('cognito.mfa_setup')=="MFA_ENABLED") {
@@ -877,7 +877,7 @@ class AwsCognitoClient
      * @param array $attributes
      * @return array $clientMetadata (optional)
      */
-    protected function buildClientMetadata(array $attributes, array $clientMetadata=null)
+    protected function buildClientMetadata(array $attributes, ?array $clientMetadata = null)
     {
         if (!empty($clientMetadata)) {
             $userAttributes = array_merge($attributes, $clientMetadata);

--- a/src/Exceptions/AwsCognitoException.php
+++ b/src/Exceptions/AwsCognitoException.php
@@ -19,7 +19,7 @@ class AwsCognitoException extends HttpException
      *
      * @return void
      */
-    public function __construct($message="AWS Cognito Error", $code=null, Throwable $previous=null, array $headers=[])
+    public function __construct($message = "AWS Cognito Error", $code = null, ?Throwable $previous = null, array $headers = [])
     {
         parent::__construct(400, $message, $previous, $headers, $code);
     }

--- a/src/Exceptions/DBConnectionException.php
+++ b/src/Exceptions/DBConnectionException.php
@@ -14,7 +14,7 @@ class DBConnectionException extends PDOException
      *
      * @return void
      */
-    public function report($message="Database Connection Error", $code=null, Throwable $previous=null)
+    public function report($message = "Database Connection Error", $code = null, ?Throwable $previous = null)
     {
         parent::report($message, [], $code, $previous);
     }

--- a/src/Exceptions/InvalidUserException.php
+++ b/src/Exceptions/InvalidUserException.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 class InvalidUserException extends HttpException
 {
 
-    public function __construct(string $message = 'Invalid Cognito User', \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = 'Invalid Cognito User', ?\Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(400, $message, $previous, $headers, $code);
     }

--- a/src/Exceptions/NoLocalUserException.php
+++ b/src/Exceptions/NoLocalUserException.php
@@ -19,7 +19,7 @@ class NoLocalUserException extends HttpException
      *
      * @return void
      */
-    public function __construct(string $message = 'User does not exist locally.', Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = 'User does not exist locally.', ?Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(401, $message, $previous, $headers, $code);
     }

--- a/src/Guards/CognitoTokenGuard.php
+++ b/src/Guards/CognitoTokenGuard.php
@@ -99,8 +99,8 @@ class CognitoTokenGuard extends TokenGuard
         AwsCognito $cognito,
         AwsCognitoClient $client,
         Request $request,
-        UserProvider $provider = null,
-        string $keyUsername = null
+        ?UserProvider $provider = null,
+        ?string $keyUsername = null
     ) {
         $this->cognito = $cognito;
         $this->client = $client;

--- a/src/Guards/Traits/CognitoMFA.php
+++ b/src/Guards/Traits/CognitoMFA.php
@@ -82,7 +82,7 @@ trait CognitoMFA
      *
      * @return array
      */
-    public function associateSoftwareTokenMFA(string $appName=null, string $userParamToAddToQR='email') {
+    public function associateSoftwareTokenMFA(?string $appName = null, string $userParamToAddToQR = 'email') {
         try {
             //Get Access Token
             $accessToken = $this->cognito->getToken();
@@ -119,7 +119,7 @@ trait CognitoMFA
      *
      * @return array
      */
-    public function verifySoftwareTokenMFA(string $userCode, string $deviceName=null) {
+    public function verifySoftwareTokenMFA(string $userCode, ?string $deviceName = null) {
         try {
             //Get Access Token
             $accessToken = $this->cognito->getToken();

--- a/src/Traits/AwsCognitoClientMFAAction.php
+++ b/src/Traits/AwsCognitoClientMFAAction.php
@@ -30,7 +30,7 @@ trait AwsCognitoClientMFAAction
      * 
      * @return mixed
      */
-    public function associateSoftwareTokenMFA(string $accessToken=null, string $session=null)
+    public function associateSoftwareTokenMFA(?string $accessToken = null, ?string $session = null)
     {
         try {
             //Build payload
@@ -67,7 +67,7 @@ trait AwsCognitoClientMFAAction
      * 
      * @return mixed
      */
-    public function verifySoftwareTokenMFA(string $userCode, string $accessToken=null, string $session=null, string $deviceName=null)
+    public function verifySoftwareTokenMFA(string $userCode, ?string $accessToken = null, ?string $session = null, ?string $deviceName = null)
     {
         try {
             //Build payload


### PR DESCRIPTION
## Summary

This PR fixes PHP 8.4 deprecation warnings for implicit nullable parameters across the codebase.

**Problem:** PHP 8.4 deprecates using `type $param = null` syntax for nullable parameters. The explicit `?type $param = null` syntax should be used instead.

**Changes:** Updated 10 files to use explicit nullable type declarations:

- `src/AwsCognitoClient.php` - `register()`, `sendResetLink()`, `inviteUser()`, `buildClientMetadata()`
- `src/Traits/AwsCognitoClientMFAAction.php` - `associateSoftwareTokenMFA()`, `verifySoftwareTokenMFA()`
- `src/Auth/RegistersUsers.php` - `invite()`, `register()`, `createCognitoUser()`
- `src/Auth/SendsPasswordResetEmails.php` - `sendResetLinkEmail()`, `sendCognitoResetLinkEmail()`
- `src/Guards/CognitoTokenGuard.php` - constructor
- `src/Guards/Traits/CognitoMFA.php` - `associateSoftwareTokenMFA()`, `verifySoftwareTokenMFA()`
- `src/Exceptions/AwsCognitoException.php` - constructor
- `src/Exceptions/DBConnectionException.php` - `report()`
- `src/Exceptions/InvalidUserException.php` - constructor
- `src/Exceptions/NoLocalUserException.php` - constructor

## Example Change

```php
// Before (deprecated in PHP 8.4)
public function register($username, $password, array $attributes = [],
    array $clientMetadata=null, string $groupname=null)

// After (explicit nullable)
public function register($username, $password, array $attributes = [],
    ?array $clientMetadata = null, ?string $groupname = null)
```

## Testing

These changes are backward compatible and do not alter functionality. The explicit nullable syntax is supported in PHP 7.1+ and is the required syntax in PHP 8.4+.

## Related

- PHP 8.4 Deprecation RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types