### PR TITLE
Remove Laravel version debug log

### DIFF
--- a/src/Providers/AwsCognitoServiceProvider.php
+++ b/src/Providers/AwsCognitoServiceProvider.php
@@ -95,7 +95,6 @@ class AwsCognitoServiceProvider extends ServiceProvider
     public function setLaravelVersion(): void
     {
         $laravelVersion = Application::VERSION;
-        Log::debug('Laravel Version: '.$laravelVersion);
         $this->laravelVersion = $laravelVersion;
     } //Function ends
 


### PR DESCRIPTION
There was recently a debug log added that runs every time the service provider is loaded. This ends up filling up our log files with the same log repeatedly.